### PR TITLE
LUC024A-53 temporarily restoring to previous solr setup for AS

### DIFF
--- a/application/libraries/solr/solr_client_archivesspace_1.php
+++ b/application/libraries/solr/solr_client_archivesspace_1.php
@@ -27,8 +27,8 @@ class solr_client_archivesspace_1
     var $dictionary = 'default';
     var $fields = array(); //copied from uoa
     //SR 2024-02-02- parameterise new config item for solr core when we understand the fix
-    //var $solr_collection = ''; //TODO move to config
-    var $solr_collection = 'collection1';
+    //var $solr_collection = 'collection1';
+    var $solr_collection = '';
     var $restriction = array();
 
 
@@ -46,7 +46,7 @@ class solr_client_archivesspace_1
 
         $CI =& get_instance();
         //SR 2024-02-02- parameterise new config item for solr core when we understand the fix
-        //$this->solr_collection = $CI->config->item('skylight_solr_core');
+        $this->solr_collection = $CI->config->item('skylight_solr_core');
         $this->base_url = $CI->config->item('skylight_solrbase');
         $this->handle_prefix = $CI->config->item('skylight_handle_prefix');
         $this->container = $CI->config->item('skylight_container_id');

--- a/application/libraries/solr/solr_client_archivesspace_1.php
+++ b/application/libraries/solr/solr_client_archivesspace_1.php
@@ -26,8 +26,9 @@ class solr_client_archivesspace_1
     var $link_bitstream = false;
     var $dictionary = 'default';
     var $fields = array(); //copied from uoa
-    //var $solr_collection = "solr/archivesspace"; //TODO move to config
-    var $solr_collection = ''; //TODO move to config
+    //SR 2024-02-02- parameterise new config item for solr core when we understand the fix
+    //var $solr_collection = ''; //TODO move to config
+    var $solr_collection = 'collection1';
     var $restriction = array();
 
 
@@ -44,7 +45,8 @@ class solr_client_archivesspace_1
         }
 
         $CI =& get_instance();
-        $this->solr_collection = $CI->config->item('skylight_solr_core');
+        //SR 2024-02-02- parameterise new config item for solr core when we understand the fix
+        //$this->solr_collection = $CI->config->item('skylight_solr_core');
         $this->base_url = $CI->config->item('skylight_solrbase');
         $this->handle_prefix = $CI->config->item('skylight_handle_prefix');
         $this->container = $CI->config->item('skylight_container_id');


### PR DESCRIPTION
Reverting the following:
    //SR 2024-02-02- parameterise new config item for solr core when we understand the fix
    //var $solr_collection = ''; //TODO move to config
    var $solr_collection = 'collection1';

and
        //SR 2024-02-02- parameterise new config item for solr core when we understand the fix
        //$this->solr_collection = $CI->config->item('skylight_solr_core');
        $this->base_url = $CI->config->item('skylight_solrbase');